### PR TITLE
Allow a different request function to be used

### DIFF
--- a/lib/Analytics.js
+++ b/lib/Analytics.js
@@ -10,7 +10,7 @@ import Timing from './hits/Timing';
 import Transaction from './hits/Transaction';
 
 export default class Analytics {
-  constructor(trackingId, clientId, version, userAgent) {
+  constructor(trackingId, clientId, version, userAgent, requestFn) {
     this.collectBaseEndpoint = 'https://www.google-analytics.com/collect?';
     this.version = version || 1;
     this.trackingId = trackingId;
@@ -18,6 +18,7 @@ export default class Analytics {
     this.userAgent = userAgent || null;
     this.customDimensions = new CustomDimensions();
     this.EnhancedEcommerce = new EnhancedEcommerce();
+    this.requestFn = requestFn || null;
 
     if (!userAgent) {
       throw new Error('You must specify a user agent in order for Google Analytics to accept the event. Use DeviceInfo.getUserAgent() from react-native-device-info for this.');
@@ -81,6 +82,10 @@ export default class Analytics {
     // Adds cache-buster.
     // Reference: https://developers.google.com/analytics/devguides/collection/protocol/v1/reference#cache-busting
     request += `&z=${Math.round(Math.random() * 1e8)}`;
+
+    if (this.requestFn) {
+      return this.requestFn(request, options);
+    }
 
     return fetch(request, options);
   }


### PR DESCRIPTION
When used on web in iOS, `fetch` is sending an options request which is being rejected by Google as an unsupported method. This allows a consumer of this library to pass in their own request function, in our case Axios, to replace fetch.